### PR TITLE
fix: broken CONTRIBUTING link in Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!--- IMPORTANT: Please review [how to contribute](../CONTRIBUTING.md) before proceeding further. -->
+<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-otp/blob/master/CONTRIBUTING.md) before proceeding further. -->
 <!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->
 
 ## Description
@@ -17,7 +17,7 @@ In particular, the ...
 
 <!--- Please insert an ‘x’ after you complete each step -->
 
-- [ ] I have followed the indications in the [CONTRIBUTING](../CONTRIBUTING.md).
+- [ ] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-otp/blob/master/CONTRIBUTING.md).
 - [ ] The documentation related to the proposed change has been updated accordingly (plus comments in code).
 - [ ] I have written new tests for my core changes, as applicable.
 - [ ] I have successfully run tests with my changes locally.


### PR DESCRIPTION
## Description

This PR fixes the broken CONTRIBUTING link by pointing to the master branch file.

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-otp/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

## Fixes

<!-- Please insert the issue numbers after the # symbol -->

- Fixes #4 
