### PR TITLE
fix(config): rename python config as envar

### DIFF
--- a/immuni_otp/core/config.py
+++ b/immuni_otp/core/config.py
@@ -19,6 +19,6 @@ OTP_CACHE_REDIS_URL: str = config("OTP_CACHE_REDIS_URL", default="redis://localh
 OTP_CACHE_REDIS_MAX_CONNECTIONS: int = config(
     "OTP_CACHE_REDIS_MAX_CONNECTIONS", default=10, cast=int
 )
-OTP_KEY_EXPIRATION_SECONDS: int = config(
+OTP_EXPIRATION_SECONDS: int = config(
     "OTP_EXPIRATION_SECONDS", default=int(timedelta(minutes=2.5).total_seconds()), cast=int
 )

--- a/immuni_otp/helpers/otp.py
+++ b/immuni_otp/helpers/otp.py
@@ -45,7 +45,7 @@ async def store(otp: str, otp_data: OtpData) -> None:
     did_set = await managers.otp_redis.set(
         key=_key_for_otp(otp),
         value=OtpDataSchema().dumps(otp_data),
-        expire=config.OTP_KEY_EXPIRATION_SECONDS,
+        expire=config.OTP_EXPIRATION_SECONDS,
         exist=StringCommandsMixin.SET_IF_NOT_EXIST,
     )
     if not did_set:

--- a/tests/test_helpers/test_otp.py
+++ b/tests/test_helpers/test_otp.py
@@ -38,7 +38,7 @@ async def test_store_success() -> None:
     expected = _OTP_DATA_SERIALIZED
     assert actual == expected
     ttl = await managers.otp_redis.ttl(key=key)
-    assert 0 < ttl <= config.OTP_KEY_EXPIRATION_SECONDS
+    assert 0 < ttl <= config.OTP_EXPIRATION_SECONDS
 
 
 async def test_store_failure_on_existent_key() -> None:


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-otp/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

Align python config name to the environment variable already used in production.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-otp/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

