### PR TITLE
fix(ci): ipv4 only to properly retry connrefused

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,7 @@ jobs:
             docker run \
                 --network container:docker_api_1 \
                 appropriate/curl \
+                -4 \
                 --verbose \
                 --retry 10 \
                 --retry-delay 1 \


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-otp/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

The CI steps to test the API healthcheck wasn't properly retrying on connection refused. A CircleCI job restart would eventually make it pass. This change aims at solving such issue.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-otp/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

